### PR TITLE
Support for confirming/cancelling Tag Deletion

### DIFF
--- a/tagmanager.js
+++ b/tagmanager.js
@@ -68,7 +68,7 @@ var TagManager = (function () {
             var canDelete = this.options.deleteHandler(this, tagString, isEmpty);
             if (!canDelete) return;
         }
-        if(this.options.strategy = 'ajax' && this.options.ajaxDelete && !isEmpty) {
+        if(this.options.strategy == 'ajax' && this.options.ajaxDelete && !isEmpty) {
             $.ajax({
                 url: this.options.ajaxDelete,
                 type: 'post',
@@ -103,7 +103,7 @@ var TagManager = (function () {
             this.$element.val('');
             return;
         }
-        if(this.options.strategy = 'ajax' && this.options.ajaxCreate && !isImport) {
+        if(this.options.strategy == 'ajax' && this.options.ajaxCreate && !isImport) {
             $.ajax({
                 url: this.options.ajaxCreate,
                 type: 'post',

--- a/tagmanager.js
+++ b/tagmanager.js
@@ -18,7 +18,7 @@ var TagManager = (function () {
                 return;
             },
             deleteHandler: function (tagManager, tag, isEmpty) {
-                return;
+                return true;
             },
             createElementHandler: function (tagManager, tagElement, isImport) {
                 tagManager.$element.before(tagElement);
@@ -65,7 +65,8 @@ var TagManager = (function () {
     TagManager.prototype.delete = function (tagId, isEmpty) {
         var tagString = $('#' + tagId).attr('tag');
         if(this.options.deleteHandler) {
-            this.options.deleteHandler(this, tagString, isEmpty);
+            var canDelete = this.options.deleteHandler(this, tagString, isEmpty);
+            if (!canDelete) return;
         }
         if(this.options.strategy = 'ajax' && this.options.ajaxDelete && !isEmpty) {
             $.ajax({

--- a/tagmanager.ts
+++ b/tagmanager.ts
@@ -49,7 +49,7 @@ class TagManager {
                 return;
             }
             , deleteHandler: function(tagManager, tag, isEmpty?) {
-                return;
+                return true;
             }
             , createElementHandler: function(tagManager, tagElement, isImport?) {
                 tagManager.$element.before(tagElement);
@@ -121,8 +121,10 @@ class TagManager {
     delete(tagId: string, isEmpty?: bool) {
         var tagString = $('#' + tagId).attr('tag');
 
-        if (this.options.deleteHandler)
-            this.options.deleteHandler(this, tagString, isEmpty);
+        if (this.options.deleteHandler) {
+            var canDelete = this.options.deleteHandler(this, tagString, isEmpty);
+            if (!canDelete) return;
+        }
 
         if (this.options.strategy = 'ajax'
             && this.options.ajaxDelete

--- a/tagmanager.ts
+++ b/tagmanager.ts
@@ -126,7 +126,7 @@ class TagManager {
             if (!canDelete) return;
         }
 
-        if (this.options.strategy = 'ajax'
+        if (this.options.strategy == 'ajax'
             && this.options.ajaxDelete
             && !isEmpty) {
 
@@ -176,7 +176,7 @@ class TagManager {
             return;
         }
 
-        if (this.options.strategy = 'ajax'
+        if (this.options.strategy == 'ajax'
             && this.options.ajaxCreate
             && !isImport) {
 


### PR DESCRIPTION
While I found tagmanager to be quite useful, one option I required but did not see was the ability for the "deleteHandler" callback to indicate that we should _not_ be deleting the tag.

e.g. the deleteHandler could trigger an alert/popup to confirm with the user that they did intend to delete the Tag, and the User could then cancel the action.

Only gotcha is that while it was easy to add it in, it _did_ change the semantics of the deleteHandler as it would now be required to return a boolean value to indicate whether or not the Tag should be deleted or not in the UI.
